### PR TITLE
Add Azure OpenAI provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,33 @@ All providers use LangChain.js with Zod schemas for structured output:
 |----------|---------|-------|
 | Anthropic | `@langchain/anthropic` | Recommended (claude-sonnet-4) |
 | OpenAI | `@langchain/openai` | gpt-4o, gpt-4-turbo |
+| Azure OpenAI | `@langchain/openai` | Enterprise Azure deployments |
 | Google Gemini | `@langchain/google-genai` | gemini-1.5-pro, gemini-2.0-flash |
 | Ollama | `@langchain/ollama` | Local models (llama3.1, codellama) |
 | Cursor | Custom adapter | IDE integration |
 | Amp | Custom adapter | ampcode.com CLI agent |
+
+### Azure OpenAI Configuration
+
+For Azure OpenAI, set these environment variables:
+
+```bash
+AZURE_OPENAI_API_KEY=<your-api-key>
+AZURE_OPENAI_ENDPOINT=https://<resource-name>.openai.azure.com/
+AZURE_OPENAI_API_VERSION=2024-02-15-preview
+AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4
+```
+
+Then configure in `devloop.config.js`:
+
+```javascript
+module.exports = {
+  ai: {
+    provider: 'azure',
+    model: 'gpt-4',  // Your deployment name
+  },
+};
+```
 
 ## For AI Agents: MCP Tools
 

--- a/commit-msg.txt
+++ b/commit-msg.txt
@@ -1,0 +1,16 @@
+Add Azure OpenAI provider support
+
+Enables dev-loop to work with Azure OpenAI deployments via LangChain's
+AzureChatOpenAI class. Enterprise users with Azure OpenAI can now use
+dev-loop by setting environment variables and configuring provider: 'azure'.
+
+Changes:
+- Add 'azure' to AIProviderName type
+- Add AzureChatOpenAI case in createLangChainModel()
+- Add helper to extract Azure instance name from endpoint URL
+- Update env-detector with AZURE_OPENAI_API_KEY detection
+- Add Azure model options to model-list
+- Update Zod schema to include 'azure' provider
+- Add Azure configuration documentation to README
+
+Closes #1

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "glob": "^10.5.0",
         "immer": "^10.0.3",
         "inquirer": "^9.2.12",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.1.0",
         "ora": "^5.4.1",
         "partial-json": "^0.1.7",
         "task-master-ai": "^0.40.0",
@@ -5938,56 +5938,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.4.0.tgz",
-      "integrity": "sha512-qSbfq9mXbLMqmPEjijl32f3ZEmiHekebRggPdPjhHI6t1CsAQOR2Aw/SuTDftk3/l2aaPHpwP3xM2DkgBA1ANw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "2.4.0",
-        "@opentelemetry/resources": "2.4.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-KtcyFHssTn5ZgDu6SXmUznS80OFs/wN7y6MyFRRcKU6TOw8hNcGxKvt8hsdaLJfhzUszNSjURetq5Qpkad14Gw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.4.0.tgz",
-      "integrity": "sha512-RWvGLj2lMDZd7M/5tjkI/2VHMpXebLgPKvBUd9LRasEWR2xAynDwEYZuLvY9P2NGG73HF07jbbgWX2C9oavcQg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "2.4.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -12005,16 +11955,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {

--- a/src/cli/utils/env-detector.ts
+++ b/src/cli/utils/env-detector.ts
@@ -38,7 +38,8 @@ export interface ProviderDetectionConfig {
  */
 const PROVIDER_ENV_VARS: Record<Exclude<AIProviderName, 'cursor'>, string[]> = {
   anthropic: ['ANTHROPIC_API_KEY'],
-  openai: ['OPENAI_API_KEY', 'AZURE_OPENAI_API_KEY'],
+  openai: ['OPENAI_API_KEY'],
+  azure: ['AZURE_OPENAI_API_KEY'],
   gemini: ['GOOGLE_AI_API_KEY', 'GEMINI_API_KEY'],
   ollama: ['OLLAMA_API_KEY', 'OLLAMA_HOST'],
   amp: ['AMP_API_KEY', 'AMP_CONFIG'], // Amp typically uses its own auth
@@ -250,7 +251,7 @@ export async function getBestAvailableProvider(
   const available = detected.filter(p => p.hasApiKey);
 
   // Priority order
-  const priority: AIProviderName[] = ['anthropic', 'openai', 'cursor', 'gemini', 'ollama'];
+  const priority: AIProviderName[] = ['anthropic', 'openai', 'azure', 'cursor', 'gemini', 'ollama'];
 
   for (const provider of priority) {
     if (available.some(p => p.provider === provider)) {

--- a/src/cli/utils/model-list.ts
+++ b/src/cli/utils/model-list.ts
@@ -24,6 +24,12 @@ export const PROVIDER_MODELS: Record<AIProviderName, ModelOption[]> = {
     { name: 'GPT-4', value: 'gpt-4' },
     { name: 'GPT-3.5 Turbo', value: 'gpt-3.5-turbo' },
   ],
+  azure: [
+    { name: 'GPT-4o (Use Your Deployment Name)', value: 'gpt-4o' },
+    { name: 'GPT-4 Turbo', value: 'gpt-4-turbo' },
+    { name: 'GPT-4', value: 'gpt-4' },
+    { name: 'GPT-3.5 Turbo', value: 'gpt-35-turbo' },
+  ],
   gemini: [
     { name: 'Gemini 2.0 Flash (Latest, Fast)', value: 'gemini-2.0-flash' },
     { name: 'Gemini 1.5 Pro', value: 'gemini-1.5-pro' },

--- a/src/config/schema/core.ts
+++ b/src/config/schema/core.ts
@@ -25,7 +25,7 @@ const configSchemaBase = z.object({
     path: z.string().default('.devloop/metrics.json'),
   }).optional(),
   ai: z.object({
-    provider: z.enum(['anthropic', 'openai', 'gemini', 'ollama', 'cursor', 'amp']),
+    provider: z.enum(['anthropic', 'openai', 'azure', 'gemini', 'ollama', 'cursor', 'amp']),
     model: z.string(), // For cursor/amp: 'auto' (default) or specific model name
     fallback: z.string().optional(),
     apiKey: z.string().optional(), // Not used for cursor/amp provider

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ export type TaskType = 'analysis' | 'fix' | 'generate' | 'investigate';
 
 export type InterventionMode = 'autonomous' | 'review' | 'hybrid';
 
-export type AIProviderName = 'anthropic' | 'openai' | 'gemini' | 'ollama' | 'cursor' | 'amp';
+export type AIProviderName = 'anthropic' | 'openai' | 'azure' | 'gemini' | 'ollama' | 'cursor' | 'amp';
 
 export type TestRunnerName = 'playwright' | 'cypress';
 


### PR DESCRIPTION
## Summary
- Adds Azure OpenAI as a supported AI provider
- Uses LangChain's `AzureChatOpenAI` class for Azure-specific authentication

## Changes
- Added `'azure'` to `AIProviderName` type
- Implemented Azure support in `createLangChainModel()` with automatic endpoint parsing
- Added `AZURE_OPENAI_API_KEY` to environment variable detection
- Added Azure models to the model selection list
- Updated Zod config schema to include `'azure'` provider
- Added Azure configuration documentation to README

## Configuration
```javascript
// devloop.config.js
module.exports = {
  ai: {
    provider: 'azure',
    model: 'gpt-4',  // Your deployment name
  },
};
```

## Environment Variables
```bash
AZURE_OPENAI_API_KEY=<your-api-key>
AZURE_OPENAI_ENDPOINT=https://<resource-name>.openai.azure.com/
AZURE_OPENAI_API_VERSION=2024-02-15-preview
AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4
```

## Test plan
- [ ] Build passes with `npm run build`
- [ ] TypeScript compiles with no errors
- [ ] Manual test with Azure OpenAI deployment

Closes #1
